### PR TITLE
Remove any calls to log.Fatal to allow for defers to run

### DIFF
--- a/08-fatal/README.md
+++ b/08-fatal/README.md
@@ -1,5 +1,5 @@
-# 7. Business-Logic Tests
+# 8. Fatal
 
-- Add test incorporating Create, Get, & List
-- Add test helper function for setting up the database
+- Create `run() error` function
+- Remove any calls to `log.Fatal`
 

--- a/08-fatal/README.md
+++ b/08-fatal/README.md
@@ -1,0 +1,5 @@
+# 7. Business-Logic Tests
+
+- Add test incorporating Create, Get, & List
+- Add test helper function for setting up the database
+

--- a/08-fatal/cmd/salesapi/internal/handlers/products.go
+++ b/08-fatal/cmd/salesapi/internal/handlers/products.go
@@ -1,0 +1,81 @@
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"github.com/ardanlabs/service-training/08-fatal/internal/products"
+	"github.com/go-chi/chi"
+	"github.com/jmoiron/sqlx"
+)
+
+type Products struct {
+	db *sqlx.DB
+
+	http.Handler
+}
+
+func NewProducts(db *sqlx.DB) *Products {
+	p := Products{db: db}
+
+	r := chi.NewRouter()
+	r.Post("/v1/products", p.Create)
+	r.Get("/v1/products", p.List)
+	r.Get("/v1/products/{id}", p.Get)
+	p.Handler = r
+
+	return &p
+}
+
+func (s *Products) Create(w http.ResponseWriter, r *http.Request) {
+	var p products.Product
+	if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
+		log.Printf("error: decoding product: %s", err)
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		return
+	}
+
+	if err := products.Create(s.db, &p); err != nil {
+		log.Printf("error: creating product: %s", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if err := json.NewEncoder(w).Encode(p); err != nil {
+		log.Printf("error: encoding response: %s", err)
+		return
+	}
+}
+
+func (s *Products) List(w http.ResponseWriter, r *http.Request) {
+	list, err := products.List(s.db)
+	if err != nil {
+		log.Printf("error: listing products: %s", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// TODO: Don't return an array (return an object with an array).
+	//       Make a named response type.
+	if err := json.NewEncoder(w).Encode(list); err != nil {
+		log.Printf("error: encoding response: %s", err)
+		return
+	}
+}
+
+func (s *Products) Get(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	p, err := products.Get(s.db, id)
+	if err != nil {
+		log.Printf("error: getting product: %s", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if err := json.NewEncoder(w).Encode(p); err != nil {
+		log.Printf("error: encoding response: %s", err)
+		return
+	}
+}

--- a/08-fatal/cmd/salesapi/main.go
+++ b/08-fatal/cmd/salesapi/main.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/ardanlabs/service-training/08-fatal/cmd/salesapi/internal/handlers"
+	"github.com/ardanlabs/service-training/08-fatal/internal/products"
+	"github.com/jmoiron/sqlx"
+	"github.com/kelseyhightower/envconfig"
+	"github.com/pkg/errors"
+
+	_ "github.com/lib/pq"
+)
+
+// This is the application name.
+const name = "salesapi"
+
+type config struct {
+	// NOTE: We don't pass in a connection string b/c our application may assume
+	//       certain parameters are set.
+	DB struct {
+		User     string `default:"postgres"`
+		Password string `default:"postgres" json:"-"` // Prevent the marshalling of secrets.
+		Host     string `default:"localhost"`
+		Name     string `default:"postgres"`
+
+		DisableTLS bool `default:"false" envconfig:"disable_tls"`
+	}
+
+	HTTP struct {
+		Address string `default:":8000"`
+	}
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %s", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	// Process inputs.
+	var flags struct {
+		configOnly bool
+	}
+	flag.Usage = func() {
+		fmt.Print("This daemon is a service which manages products.\n\nUsage of sales-api:\n\nsales-api [flags]\n\n")
+		flag.CommandLine.SetOutput(os.Stdout)
+		flag.PrintDefaults()
+		fmt.Print("\nConfiguration:\n\n")
+		envconfig.Usage(name, &config{})
+	}
+	flag.BoolVar(&flags.configOnly, "config-only", false, "only show parsed configuration and exit")
+	flag.Parse()
+
+	var cfg config
+	if err := envconfig.Process(name, &cfg); err != nil {
+		return errors.Wrap(err, "parsing config")
+	}
+
+	if flags.configOnly {
+		if err := json.NewEncoder(os.Stdout).Encode(cfg); err != nil {
+			return errors.Wrap(err, "encoding config as json")
+		}
+		return nil
+	}
+
+	// Initialize dependencies.
+	db, err := sqlx.Connect("postgres", products.DBConn(cfg.DB.User, cfg.DB.Password, cfg.DB.Host, cfg.DB.Name, cfg.DB.DisableTLS))
+	if err != nil {
+		return errors.Wrap(err, "connecting to db")
+	}
+	defer db.Close()
+
+	server := http.Server{
+		Addr:    cfg.HTTP.Address,
+		Handler: handlers.NewProducts(db),
+	}
+
+	serverErrors := make(chan error, 1)
+	go func() {
+		serverErrors <- server.ListenAndServe()
+	}()
+
+	osSignals := make(chan os.Signal, 1)
+	signal.Notify(osSignals, os.Interrupt, syscall.SIGTERM)
+
+	log.Print("startup complete")
+
+	select {
+	case err := <-serverErrors:
+		return errors.Wrap(err, "listening and serving")
+
+	case <-osSignals:
+		log.Print("caught signal, shutting down")
+
+		// Give outstanding requests 15 seconds to complete.
+		const timeout = 15 * time.Second
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+
+		if err := server.Shutdown(ctx); err != nil {
+			return errors.Wrap(err, "gracefully shutting down server")
+		}
+	}
+
+	log.Print("done")
+
+	return nil
+}

--- a/08-fatal/internal/products/products.go
+++ b/08-fatal/internal/products/products.go
@@ -1,0 +1,69 @@
+package products
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	"github.com/pkg/errors"
+)
+
+type Product struct {
+	ID       string `db:"product_id"`
+	Name     string `db:"name"`
+	Cost     int    `db:"cost"`
+	Quantity int    `db:"quantity"`
+}
+
+func DBConn(user, pass, host, name string, disableSSL bool) string {
+	sslMode := "require"
+	if disableSSL {
+		sslMode = "disable"
+	}
+	return fmt.Sprintf("postgres://%s:%s@%s/%s?sslmode=%s&timezone=utc",
+		user, pass, host, name, sslMode)
+}
+
+func List(db *sqlx.DB) ([]Product, error) {
+	// TODO: Catch "null" in tests with empty list.
+	var products []Product
+
+	// TODO: Talk about issues of using '*' after talking about migrations.
+	if err := db.Select(&products, "SELECT * FROM products"); err != nil {
+		return nil, errors.Wrap(err, "selecting products")
+	}
+
+	return products, nil
+}
+
+func Create(db *sqlx.DB, p *Product) error {
+	p.ID = uuid.New().String()
+
+	_, err := db.Exec(`
+		INSERT INTO products
+		(product_id, name, cost, quantity)
+		VALUES ($1, $2, $3, $4)`,
+		p.ID, p.Name, p.Cost, p.Quantity,
+	)
+	if err != nil {
+		return errors.Wrap(err, "inserting product")
+	}
+
+	return nil
+}
+
+func Get(db *sqlx.DB, id string) (*Product, error) {
+	var p Product
+
+	err := db.Get(&p, `
+		SELECT * FROM products
+		WHERE product_id = $1
+		LIMIT 1`,
+		id,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "selecting single product")
+	}
+
+	return &p, nil
+}

--- a/08-fatal/internal/products/products_test.go
+++ b/08-fatal/internal/products/products_test.go
@@ -1,0 +1,85 @@
+package products_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ardanlabs/service-training/08-fatal/internal/products"
+	"github.com/jmoiron/sqlx"
+	"github.com/kelseyhightower/envconfig"
+	_ "github.com/lib/pq"
+	"github.com/pkg/errors"
+)
+
+func TestProducts(t *testing.T) {
+	db, drop := testDB(t)
+	defer drop()
+
+	{ // Create and Get.
+		p0 := products.Product{}
+		if err := products.Create(db, &p0); err != nil {
+			t.Fatal(errors.Wrap(err, "creating product p0"))
+		}
+		p1, err := products.Get(db, p0.ID)
+		if err != nil {
+			t.Fatal(errors.Wrap(err, "getting product p0"))
+		}
+		if *p1 != *p1 {
+			t.Fatalf("fetched != created: %v != %v", p1, p0)
+		}
+	}
+
+	{ // List.
+		ps, err := products.List(db)
+		if err != nil {
+			t.Fatal(errors.Wrap(err, "listing products"))
+		}
+		if exp, got := 1, len(ps); exp != got {
+			t.Fatalf("expected product list size %v, got %v", exp, got)
+		}
+	}
+}
+
+func testDB(t *testing.T) (*sqlx.DB, func()) {
+	var cfg struct {
+		DB struct {
+			User     string `default:"postgres"`
+			Password string `default:"postgres"`
+			Host     string `default:"localhost"`
+			Name     string `default:"postgres"`
+		}
+	}
+	envconfig.MustProcess("TEST", &cfg)
+
+	db0, err := sqlx.Connect("postgres", products.DBConn(cfg.DB.User, cfg.DB.Password, cfg.DB.Host, cfg.DB.Name, true))
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "connecting to db"))
+	}
+
+	newDB := fmt.Sprintf("%v_%v", strings.ToLower(t.Name()), time.Now().UnixNano())
+	db0.Exec("CREATE DATABASE " + newDB)
+
+	db, err := sqlx.Connect("postgres", products.DBConn(cfg.DB.User, cfg.DB.Password, cfg.DB.Host, newDB, true))
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "connecting to db"))
+	}
+
+	schema, err := ioutil.ReadFile(os.ExpandEnv("$GOPATH/src/github.com/ardanlabs/service-training/07-business-logic-tests/schema.sql"))
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "reading schema file"))
+	}
+	if _, err := db.Exec(string(schema)); err != nil {
+		t.Fatal(errors.Wrap(err, "migrating"))
+	}
+
+	return db, func() {
+		// Cleanup
+		db.Close()
+		db0.Exec("DROP DATABASE " + newDB)
+		db0.Close()
+	}
+}

--- a/08-fatal/schema.sql
+++ b/08-fatal/schema.sql
@@ -1,0 +1,8 @@
+CREATE TABLE products (
+	product_id	UUID,
+	name		VARCHAR(255),
+	cost		INT,
+	quantity	INT,
+
+	PRIMARY KEY (product_id)
+);


### PR DESCRIPTION
Calls to `log.Fatal` are similar to `panic` in that defers are not executed due to a call to `os.Exit`.