### PR TITLE
Use explicit structs with methods for middleware with deps

### DIFF
--- a/36-self-shutdown/cmd/sales-api/internal/handlers/routes.go
+++ b/36-self-shutdown/cmd/sales-api/internal/handlers/routes.go
@@ -14,7 +14,12 @@ import (
 // API constructs an http.Handler with all application routes defined.
 func API(shutdown chan os.Signal, db *sqlx.DB, log *log.Logger, authenticator *auth.Authenticator) http.Handler {
 
-	app := web.New(shutdown, log, mid.RequestLogger(log), mid.ErrorHandler(log), mid.Metrics, mid.PanicHandler)
+	// Create the middleware that log requests and handle errors.
+	loggerMW := mid.RequestLogger{Log: log}
+	errorMW := mid.ErrorHandler{Log: log}
+
+	// Construct the web.App which holds all routes as well as a chain of common Middleware.
+	app := web.New(shutdown, log, loggerMW.Handle, errorMW.Handle, mid.Metrics, mid.PanicHandler)
 
 	// Create the middleware that can authenticate and authorize requests.
 	authmw := mid.Auth{

--- a/36-self-shutdown/cmd/sales-api/internal/handlers/routes.go
+++ b/36-self-shutdown/cmd/sales-api/internal/handlers/routes.go
@@ -14,17 +14,11 @@ import (
 // API constructs an http.Handler with all application routes defined.
 func API(shutdown chan os.Signal, db *sqlx.DB, log *log.Logger, authenticator *auth.Authenticator) http.Handler {
 
-	// Create the middleware that log requests and handle errors.
-	loggerMW := mid.RequestLogger{Log: log}
-	errorMW := mid.ErrorHandler{Log: log}
+	// Create the variable that contains all Middleware functions.
+	mw := mid.Middleware{Log: log, Authenticator: authenticator}
 
-	// Construct the web.App which holds all routes as well as a chain of common Middleware.
-	app := web.New(shutdown, log, loggerMW.Handle, errorMW.Handle, mid.Metrics, mid.PanicHandler)
-
-	// Create the middleware that can authenticate and authorize requests.
-	authmw := mid.Auth{
-		Authenticator: authenticator,
-	}
+	// Construct the web.App which holds all routes as well as common Middleware.
+	app := web.New(shutdown, log, mw.Logger, mw.Errors, mw.Metrics, mw.Panics)
 
 	{
 		// Register health check handler. This route is not authenticated.
@@ -45,14 +39,14 @@ func API(shutdown chan os.Signal, db *sqlx.DB, log *log.Logger, authenticator *a
 		// Register Product handlers. Ensure all routes are authenticated.
 		p := Products{db: db, log: log}
 
-		app.Handle(http.MethodGet, "/v1/products", p.List, authmw.Authenticate)
-		app.Handle(http.MethodGet, "/v1/products/{id}", p.Get, authmw.Authenticate)
-		app.Handle(http.MethodPost, "/v1/products", p.Create, authmw.Authenticate)
-		app.Handle(http.MethodPut, "/v1/products/{id}", p.Update, authmw.Authenticate)
-		app.Handle(http.MethodDelete, "/v1/products/{id}", p.Delete, authmw.Authenticate, authmw.HasRole(auth.RoleAdmin))
+		app.Handle(http.MethodGet, "/v1/products", p.List, mw.Authenticate)
+		app.Handle(http.MethodGet, "/v1/products/{id}", p.Get, mw.Authenticate)
+		app.Handle(http.MethodPost, "/v1/products", p.Create, mw.Authenticate)
+		app.Handle(http.MethodPut, "/v1/products/{id}", p.Update, mw.Authenticate)
+		app.Handle(http.MethodDelete, "/v1/products/{id}", p.Delete, mw.Authenticate, mw.HasRole(auth.RoleAdmin))
 
-		app.Handle(http.MethodPost, "/v1/products/{id}/sales", p.AddSale, authmw.Authenticate, authmw.HasRole(auth.RoleAdmin))
-		app.Handle(http.MethodGet, "/v1/products/{id}/sales", p.ListSales, authmw.Authenticate)
+		app.Handle(http.MethodPost, "/v1/products/{id}/sales", p.AddSale, mw.Authenticate, mw.HasRole(auth.RoleAdmin))
+		app.Handle(http.MethodGet, "/v1/products/{id}/sales", p.ListSales, mw.Authenticate)
 	}
 
 	return app

--- a/36-self-shutdown/internal/mid/auth.go
+++ b/36-self-shutdown/internal/mid/auth.go
@@ -11,15 +11,8 @@ import (
 	"go.opencensus.io/trace"
 )
 
-// Auth is used to authenticate and authorize HTTP requests.
-type Auth struct {
-	Authenticator *auth.Authenticator
-}
-
 // Authenticate validates a JWT from the `Authorization` header.
-func (mw *Auth) Authenticate(after web.Handler) web.Handler {
-
-	// Wrap this handler around the next one provided.
+func (mw *Middleware) Authenticate(after web.Handler) web.Handler {
 	h := func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 		ctx, span := trace.StartSpan(ctx, "internal.mid.Authenticate")
 		defer span.End()
@@ -69,7 +62,7 @@ var ErrForbidden = web.ErrorWithStatus(errors.New("you are not authorized for th
 
 // HasRole validates that an authenticated user has at least one role from a
 // specified list. This method constructs the actual function that is used.
-func (mw *Auth) HasRole(roles ...string) web.Middleware {
+func (mw *Middleware) HasRole(roles ...string) web.Middleware {
 	fn := func(next web.Handler) web.Handler {
 		h := func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 			ctx, span := trace.StartSpan(ctx, "internal.mid.HasRole")

--- a/36-self-shutdown/internal/mid/errors.go
+++ b/36-self-shutdown/internal/mid/errors.go
@@ -3,22 +3,16 @@ package mid
 import (
 	"context"
 	"errors"
-	"log"
 	"net/http"
 
 	"github.com/ardanlabs/garagesale/internal/platform/web"
 	"go.opencensus.io/trace"
 )
 
-// ErrorHandler holds a Middlware that handles errors coming out of the call
-// chain. It detects normal applications errors which are used to respond to
-// the client in a uniform way. Unexpected errors (status >= 500) are logged.
-type ErrorHandler struct {
-	Log *log.Logger
-}
-
-// Handle is the actual Middleware function to be ran when building the chain.
-func (mw *ErrorHandler) Handle(before web.Handler) web.Handler {
+// Errors handles errors coming out of the call chain. It detects normal
+// application errors which are used to respond to the client in a uniform way.
+// Unexpected errors (status >= 500) are logged.
+func (mw *Middleware) Errors(before web.Handler) web.Handler {
 	h := func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 		ctx, span := trace.StartSpan(ctx, "internal.mid.ErrorHandler")
 		defer span.End()

--- a/36-self-shutdown/internal/mid/logger.go
+++ b/36-self-shutdown/internal/mid/logger.go
@@ -12,34 +12,34 @@ import (
 
 // RequestLogger writes some information about the request to the logs in
 // the format: TraceID : (200) GET /foo -> IP ADDR (latency)
-func RequestLogger(log *log.Logger) web.Middleware {
+type RequestLogger struct {
+	Log *log.Logger
+}
 
-	// Wrap this handler around the next one provided.
-	mw := func(before web.Handler) web.Handler {
-		h := func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-			ctx, span := trace.StartSpan(ctx, "internal.mid.RequestLogger")
-			defer span.End()
+// Handle is the actual Middleware function to be ran when building the chain.
+func (mw *RequestLogger) Handle(before web.Handler) web.Handler {
+	h := func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		ctx, span := trace.StartSpan(ctx, "internal.mid.RequestLogger")
+		defer span.End()
 
-			// If the context is missing this value, request the service
-			// to be shutdown gracefully.
-			v, ok := ctx.Value(web.KeyValues).(*web.Values)
-			if !ok {
-				return web.Shutdown("web value missing from context")
-			}
-
-			err := before(ctx, w, r)
-
-			log.Printf("%s : (%d) : %s %s -> %s (%s)",
-				v.TraceID, v.StatusCode,
-				r.Method, r.URL.Path,
-				r.RemoteAddr, time.Since(v.Start),
-			)
-
-			// Return the error so it can be handled further up the chain.
-			return err
+		// If the context is missing this value, request the service
+		// to be shutdown gracefully.
+		v, ok := ctx.Value(web.KeyValues).(*web.Values)
+		if !ok {
+			return web.Shutdown("web value missing from context")
 		}
-		return h
+
+		err := before(ctx, w, r)
+
+		mw.Log.Printf("%s : (%d) : %s %s -> %s (%s)",
+			v.TraceID, v.StatusCode,
+			r.Method, r.URL.Path,
+			r.RemoteAddr, time.Since(v.Start),
+		)
+
+		// Return the error so it can be handled further up the chain.
+		return err
 	}
 
-	return mw
+	return h
 }

--- a/36-self-shutdown/internal/mid/logger.go
+++ b/36-self-shutdown/internal/mid/logger.go
@@ -2,7 +2,6 @@ package mid
 
 import (
 	"context"
-	"log"
 	"net/http"
 	"time"
 
@@ -10,14 +9,9 @@ import (
 	"go.opencensus.io/trace"
 )
 
-// RequestLogger writes some information about the request to the logs in
-// the format: TraceID : (200) GET /foo -> IP ADDR (latency)
-type RequestLogger struct {
-	Log *log.Logger
-}
-
-// Handle is the actual Middleware function to be ran when building the chain.
-func (mw *RequestLogger) Handle(before web.Handler) web.Handler {
+// Logger writes some information about the request to the logs in the
+// format: TraceID : (200) GET /foo -> IP ADDR (latency)
+func (mw *Middleware) Logger(before web.Handler) web.Handler {
 	h := func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 		ctx, span := trace.StartSpan(ctx, "internal.mid.RequestLogger")
 		defer span.End()

--- a/36-self-shutdown/internal/mid/metrics.go
+++ b/36-self-shutdown/internal/mid/metrics.go
@@ -22,7 +22,7 @@ var m = struct {
 }
 
 // Metrics updates program counters.
-func Metrics(before web.Handler) web.Handler {
+func (mw *Middleware) Metrics(before web.Handler) web.Handler {
 
 	h := func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 		ctx, span := trace.StartSpan(ctx, "internal.mid.Metrics")

--- a/36-self-shutdown/internal/mid/mid.go
+++ b/36-self-shutdown/internal/mid/mid.go
@@ -1,0 +1,14 @@
+package mid
+
+import (
+	"log"
+
+	"github.com/ardanlabs/garagesale/internal/platform/auth"
+)
+
+// Middleware holds the required state for all web.Middleware functions in this
+// package. Its methods are defined in separate files.
+type Middleware struct {
+	Log           *log.Logger
+	Authenticator *auth.Authenticator
+}

--- a/36-self-shutdown/internal/mid/panics.go
+++ b/36-self-shutdown/internal/mid/panics.go
@@ -9,9 +9,9 @@ import (
 	"go.opencensus.io/trace"
 )
 
-// PanicHandler recovers from panics and converts the panic to an error so it
-// is reported in Metrics and handled in ErrorHandler.
-func PanicHandler(next web.Handler) web.Handler {
+// Panics recovers from panics and converts the panic to an error so it is
+// reported in Metrics and handled in Errors.
+func (mw *Middleware) Panics(next web.Handler) web.Handler {
 	h := func(ctx context.Context, w http.ResponseWriter, r *http.Request) (err error) {
 		ctx, span := trace.StartSpan(ctx, "internal.mid.PanicHandler")
 		defer span.End()


### PR DESCRIPTION
This PR is to settle on naming and conventions regarding middleware that have state such as `ErrorHandler` and `RequestLogger`.

@ardan-bkennedy and I decided the closure method was hiding too much and seemed too clever.

I am not entirely happy with the names. There is the types (`mid.ErrorHandler`), the methods (`Handle`), the variables in the routes file (`errorMW`), etc

There are other differences between middleware here and in `service` but that's not the point of this PR.
