### PR TITLE
Fixed shell command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,12 @@ command to define a git alias called `dirdiff`:
 git config --global alias.dirdiff 'diff -p --stat -w --no-index'
 ```
 
-With that alias in place, run this command from the top level folder to see the
+With that alias in place, run this command from the training folder created previously to see the
 differences between the `01-startup` directory and the `02-shutdown` directory.
 
 ```sh
-git dirdiff 01-startup 02-shutdown`
+cd ~/training
+git dirdiff service-training/01-startup/ service-training/02-shutdown/
 ```
 
 ---


### PR DESCRIPTION
If a trainee follows the shell commands as is, this command will run inside the ~/training/garagesale directory and will result in a 
```
error: Could not access '01-startup'
```
I fixed the directory and also a grave accent (`) character at the end of the command.